### PR TITLE
Fix midpoint when padding, added ListOrderTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 FractionalIndexing.sln.DotSettings.user
+
+.vs/

--- a/FractionalIndexing.Tests/ListOrderTests.cs
+++ b/FractionalIndexing.Tests/ListOrderTests.cs
@@ -1,0 +1,176 @@
+﻿using NUnit.Framework;
+
+namespace FractionalIndexing.Tests;
+
+public class ListOrderTests
+{
+    [Test]
+    public void MoveFirst_ManyTimes_ShouldSortAsExpected()
+    {
+        // Arrange
+        const int numberOfIterations = 1000;
+
+        var p1 = new Person(1, OrderKeyGenerator.GenerateKeyBetween(null, null));
+        var p2 = new Person(3, OrderKeyGenerator.GenerateKeyBetween(p1.Order, null));
+        var p3 = new Person(2, OrderKeyGenerator.GenerateKeyBetween(p2.Order, null));
+        var list = new List<Person> { p1, p2, p3 };
+
+        TestContext.WriteLine("Initial list");
+        this.PrintList(list);
+
+        // Act
+        var comparer = new PersonSortComparer();
+
+        for (var i = 0; i < numberOfIterations; i++)
+        {
+            var first = list.First();
+            var lastIndex = list.Count - 1;
+            var last = list[lastIndex];
+            list[lastIndex] = last with { Order = OrderKeyGenerator.GenerateKeyBetween(null, first.Order) };
+            list.Sort(comparer);
+
+            TestContext.WriteLine(string.Empty);
+            TestContext.WriteLine($"Move first {i + 1} times");
+            this.PrintList(list);
+
+            // Assert
+            Assert.That(list[0].Id, Is.EqualTo(last.Id));
+        }
+    }
+
+    [Test]
+    public void MoveLast_ManyTimes_ShouldSortAsExpected()
+    {
+        // Arrange
+        const int numberOfIterations = 1000;
+
+        var p1 = new Person(1, OrderKeyGenerator.GenerateKeyBetween(null, null));
+        var p2 = new Person(3, OrderKeyGenerator.GenerateKeyBetween(p1.Order, null));
+        var p3 = new Person(2, OrderKeyGenerator.GenerateKeyBetween(p2.Order, null));
+        var list = new List<Person> { p1, p2, p3 };
+
+        TestContext.WriteLine("Initial list");
+        this.PrintList(list);
+
+        // Act
+        var comparer = new PersonSortComparer();
+
+        for (var i = 0; i < numberOfIterations; i++)
+        {
+            var first = list.First();
+            var last = list.Last();
+            list[0] = first with { Order = OrderKeyGenerator.GenerateKeyBetween(last.Order, null) };
+            list.Sort(comparer);
+
+            TestContext.WriteLine(string.Empty);
+            TestContext.WriteLine($"Move last {i + 1} times");
+            this.PrintList(list);
+
+            // Assert
+            Assert.That(list.Last().Id, Is.EqualTo(first.Id));
+        }
+    }
+
+    [Test]
+    public void MoveFirstToMiddle_ManyTimes_ShouldSortAsExpected()
+    {
+        // Arrange
+        const int numberOfIterations = 1000;
+
+        var p1 = new Person(1, OrderKeyGenerator.GenerateKeyBetween(null, null));
+        var p2 = new Person(3, OrderKeyGenerator.GenerateKeyBetween(p1.Order, null));
+        var p3 = new Person(2, OrderKeyGenerator.GenerateKeyBetween(p2.Order, null));
+        var list = new List<Person> { p1, p2, p3 };
+
+        TestContext.WriteLine("-- initial list --");
+        this.PrintList(list);
+
+        // Act
+        var comparer = new PersonSortComparer();
+        const int indexToMoveTo = 1;
+
+        for (var i = 0; i < numberOfIterations; i++)
+        {
+            var first = list.First();
+            var last = list.Last();
+            var middle = list[indexToMoveTo];
+
+            list[0] = first with { Order = OrderKeyGenerator.GenerateKeyBetween(middle.Order, last.Order) };
+
+            list.Sort(comparer);
+
+            TestContext.WriteLine(string.Empty);
+            TestContext.WriteLine($"Move first to the middle {i + 1} times");
+            this.PrintList(list);
+
+            // Assert
+            Assert.That(list[indexToMoveTo].Id, Is.EqualTo(first.Id));
+        }
+    }
+
+    [Test]
+    public void MoveLastToMiddle_ManyTimes_ShouldSortAsExpected()
+    {
+        // Arrange
+        const int numberOfIterations = 1000;
+
+        var p1 = new Person(1, OrderKeyGenerator.GenerateKeyBetween(null, null));
+        var p2 = new Person(3, OrderKeyGenerator.GenerateKeyBetween(p1.Order, null));
+        var p3 = new Person(2, OrderKeyGenerator.GenerateKeyBetween(p2.Order, null));
+        var list = new List<Person> { p1, p2, p3 };
+
+        TestContext.WriteLine("-- initial list --");
+        this.PrintList(list);
+
+        // Act
+        var comparer = new PersonSortComparer();
+
+        for (var i = 0; i < numberOfIterations; i++)
+        {
+            var first = list.First();
+            var last = list.Last();
+            var middle = list[1];
+
+            list[^1] = last with { Order = OrderKeyGenerator.GenerateKeyBetween(first.Order, middle.Order) };
+
+            list.Sort(comparer);
+
+            TestContext.WriteLine(string.Empty);
+            TestContext.WriteLine($"Move last to the middle {i + 1} times.");
+            this.PrintList(list);
+        }
+    }
+
+    private void PrintList(IEnumerable<Person> list)
+    {
+        foreach (var person in list)
+        {
+            TestContext.WriteLine(person.ToString());
+        }
+    }
+
+    private sealed record Person(int Id, string Order);
+
+    private sealed class PersonSortComparer : IComparer<Person>
+    {
+        public int Compare(Person? x, Person? y)
+        {
+            if (x == null && y == null)
+            {
+                return 0;
+            }
+
+            if (x != null && y == null)
+            {
+                return 1;
+            }
+
+            if (x == null && y != null)
+            {
+                return -1;
+            }
+
+            return string.Compare(x!.Order, y!.Order, StringComparison.Ordinal);
+        }
+    }
+}

--- a/FractionalIndexing.Tests/Tests.cs
+++ b/FractionalIndexing.Tests/Tests.cs
@@ -95,6 +95,7 @@ public class FractionalIndexingTests
         Test("a00", "a1", "invalid order key: a00");
         Test("0", "1", "invalid order key head: 0");
         Test("a1", "a0", "a1 >= a0");
+        Test("a0", "a00V", "a00G");
     }
 
     private void Test(string? a, string? b, string? exp)

--- a/FractionalIndexing/OrderKeyGenerator.cs
+++ b/FractionalIndexing/OrderKeyGenerator.cs
@@ -127,7 +127,7 @@ public static class OrderKeyGenerator
             var n = 0;
             while ((n >= a.Length ? zero : a[n]) == b[n]) n++;
 
-            if (n > 0) return b.Substring(0, n) + Midpoint(a.Substring(n), b.Substring(n), digits);
+            if (n > 0) return b.Substring(0, n) + Midpoint(n >= a.Length ? string.Empty : a.Substring(n), b.Substring(n), digits);
         }
 
         // first digits (or lack of digit) are different


### PR DESCRIPTION
In its current implementation it would occasionally throw an ArgumentOutOfRangeException (startIndex cannot be larger than length of string).

The original javascript implementation uses array.slice. In the case of an index >= the array length, it returns an empty array. This is not the case for C# Substring.

Therefor the fix.

On top of that, I added some list tests to also visualize the behavior of the algorithm in the test output. 